### PR TITLE
fix: extract regular expression for whitespaces into constant & freeze

### DIFF
--- a/lib/core/facets/kernel/blank.rb
+++ b/lib/core/facets/kernel/blank.rb
@@ -67,12 +67,14 @@ class Hash
 end
 
 class String
+  WHITESPACE_RE = /\S/.freeze
+  private_constant :WHITESPACE_RE
   # Is this string just whitespace?
   #
   #   "abc".blank?  #=> false
   #   "   ".blank?  #=> true
   def blank?
-    /\S/ !~ self
+    WHITESPACE_RE !~ self
   end
 end
 


### PR DESCRIPTION
Обнаружил через memory_profiler много алокаций для вызова String#blank?
```
allocated memory by location
-----------------------------------
 163028442  <internal:prelude>:76
  12 985 884  /bundle/2.2-0.9.0/gems/facets-3.1.0/lib/core/facets/kernel/blank.rb:75
```